### PR TITLE
Feature: Power operator '^'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ fn main() {
 
 ### Examples
 
-The implementation accepts the 4 basic mathematical operators and parenthesis. It also considers all input to be floating point. Some examples are below:
+The implementation accepts the 4 basic mathematical operators, the power operator and parenthesis. It also considers all input to be floating point. Some examples are below:
 
 Basic addition:
 ```
@@ -51,6 +51,17 @@ Lexer result: 2 + 4 * 3
 Shunting Yard result: 2 4 3 * + 
 Equation equals: 14
 ```
+
+Powers:
+```
+
+Simon$ cargo run --example main "(3 + 5) ^ 2"
+Input is: (3 + 5) ^ 2
+Lexer result: ( 3 + 5 ) ^ 2 
+Shunting Yard result: 3 5 + 2 ^ 
+Equation equals: 64
+```
+
 
 Parenthesis:
 ```

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -60,6 +60,7 @@ impl<'a> Lexer<'a> {
             },
             Some(c) if c == '(' => self.ast.push(token::Token::LeftParenthesis),
             Some(c) if c == ')' => self.ast.push(token::Token::RightParenthesis),
+            Some(c) if c == '^' => self.ast.push(token::Token::Operator(c, token::RIGHT_ASSOCIATIVE, 4)),
             Some(c) => self.errors.push(format!("Unknown identifier: {}", c)),
             None => return
         }

--- a/src/rpn_calculator.rs
+++ b/src/rpn_calculator.rs
@@ -44,6 +44,7 @@ fn operate(operator: char, left: f64, right: f64) -> f64 {
         '-' => left - right,
         '*' => left * right,
         '/' => left / right,
+        '^' => left.powf(right),
         _ => 0f64
     }
 }


### PR DESCRIPTION
This PR introduces support for the power operator `^`.

Expressions now accept numbers raised to a power.

```
Simon$ cargo run --example main "3 + 5 ^ 2"
Input is: 3 + 5 ^ 2
Lexer result: 3 + 5 ^ 2 
Shunting Yard result: 3 5 2 ^ + 
Equation equals: 28
Simon$
Simon$ cargo run --example main "3 * 5 ^ 2"
Input is: 3 * 5 ^ 2
Lexer result: 3 * 5 ^ 2 
Shunting Yard result: 3 5 2 ^ * 
Equation equals: 75
```
