### PR TITLE
Feature: Negative numbers

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -80,19 +80,10 @@ impl<'a> Lexer<'a> {
 
     // Consumes the iterator until it reaches the end of a number
     fn consume_number(&mut self) -> String {
-        // If the last operator was a sign ... prefix the number with it
-        let last_op = self.ast.last().cloned();
-        match last_op {
-            Some(token::Token::Operator(o, _, _)) => {
-                if o == '+' || o == '-' {
-                    // Pop the operator and set our sign
-                    self.ast.pop();
-                    self.sign = Some(o);
-                }
-            },
-            _ => ()
-        }
+        // Decipher the sign of the number we want to consume
+        self.decipher_sign();
 
+        // Initialize our number with the given sign
         let mut chars = vec![self.sign.unwrap_or('+')];
 
         // Reset the sign
@@ -112,6 +103,22 @@ impl<'a> Lexer<'a> {
 
         // Return out number as a String
         chars.into_iter().collect()
+    }
+
+    fn decipher_sign(&mut self) {
+        // If the last operator was a sign ... set the sign
+        let last_op = self.ast.last().cloned();
+        match last_op {
+            Some(token::Token::Operator(o, _, _)) => {
+                if o == '+' || o == '-' {
+                    // Pop the operator (because its not an operator .. its indicating the numbers'
+                    // sign) and store our sign
+                    self.ast.pop();
+                    self.sign = Some(o);
+                }
+            },
+            _ => ()
+        }
     }
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -81,20 +81,21 @@ impl<'a> Lexer<'a> {
     // Consumes the iterator until it reaches the end of a number
     fn consume_number(&mut self) -> String {
         // If the last operator was a sign ... prefix the number with it
-        let last_op = self.ast.pop();
+        let last_op = self.ast.last().cloned();
         match last_op {
             Some(token::Token::Operator(o, _, _)) => {
                 if o == '+' || o == '-' {
                     // Pop the operator and set our sign
+                    self.ast.pop();
                     self.sign = Some(o);
                 }
             },
-            None => (),
-            Some(_) => self.ast.push(last_op.unwrap())
+            _ => ()
         }
 
         let mut chars = vec![self.sign.unwrap_or('+')];
 
+        // Reset the sign
         self.sign = None;
 
         // Loop over every character until we reach a non-numeric one

--- a/src/rpn_calculator.rs
+++ b/src/rpn_calculator.rs
@@ -25,7 +25,8 @@ pub fn calculate(input: &Vec<token::Token>) -> Option<f64> {
             token::Token::WholeNumber(n) => stack.push(token::Token::DecimalNumber(n as f64)),
             token::Token::FunctionCall(_, _) => break,
             token::Token::LeftParenthesis => (),
-            token::Token::RightParenthesis => ()
+            token::Token::RightParenthesis => (),
+            token::Token::Whitespace => ()
         }
         len = input.len();
     }

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -52,22 +52,22 @@ impl<'a> ShuntingYard<'a> {
                 token::Token::WholeNumber(_) => self.output_queue.push(tok),
                 token::Token::DecimalNumber(_) => self.output_queue.push(tok),
                 token::Token::Operator(o1, o1_associativity, o1_precedence) => {
-                    loop {
+                    while self.stack.len() > 0 {
                         match self.stack.last() {
                             Some(&token::Token::Operator(_, _, o2_precedence)) => {
                                 if (o1_associativity == token::LEFT_ASSOCIATIVE &&
                                    o1_precedence <= o2_precedence) ||
                                    (o1_associativity == token::RIGHT_ASSOCIATIVE &&
-                                   o1_precedence < o2_precedence) {
-                                    self.output_queue.push(self.stack.pop().unwrap());
-                                } else {
-                                    self.stack.push(token::Token::Operator(o1, o1_associativity, o1_precedence));
-                                    break
-                                }
+                                   o1_precedence < o2_precedence) { 
+                                       self.output_queue.push(self.stack.pop().unwrap());
+                                   } else {
+                                       break
+                                   }
                             },
-                            _ => { self.stack.push(token::Token::Operator(o1, o1_associativity, o1_precedence)); break; }
+                            _ => break
                         }
                     }
+                    self.stack.push(token::Token::Operator(o1, o1_associativity, o1_precedence));
                 },
                 token::Token::LeftParenthesis => self.stack.push(token::Token::LeftParenthesis),
                 token::Token::RightParenthesis => {
@@ -77,6 +77,7 @@ impl<'a> ShuntingYard<'a> {
                             Some(&token::Token::LeftParenthesis) => {
                                 found_left_paren = true;
                                 self.stack.pop().unwrap(); 
+                                break;
                             },
                             None => {
                                 if !found_left_paren {
@@ -128,7 +129,10 @@ impl<'a> ShuntingYard<'a> {
                 token::Token::RightParenthesis => result.push_str(")"),
                 _ => ()
             };
-            result.push_str(" "); // Space separated
+
+            if tok != token::Token::Whitespace {
+                result.push_str(" "); // Space separated
+            }
         }
 
         // Return the result
@@ -153,7 +157,9 @@ impl<'a> std::string::ToString for ShuntingYard<'a> {
                 _ => ()
             };
 
-            result.push_str(" "); // Space separated
+            if tok != token::Token::Whitespace {
+                result.push_str(" "); // Space separated
+            }
         }
 
         result

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Token {
     Operator(char, u32, u32),   // Operator, associativity, precedence
     WholeNumber(i64),

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,11 +1,12 @@
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Token {
     Operator(char, u32, u32),   // Operator, associativity, precedence
     WholeNumber(i64),
     DecimalNumber(f64),
     FunctionCall(String, Vec<String>),
     LeftParenthesis,
-    RightParenthesis
+    RightParenthesis,
+    Whitespace
 }
 
 pub const LEFT_ASSOCIATIVE: u32 = 1;

--- a/tests/addition.rs
+++ b/tests/addition.rs
@@ -1,0 +1,23 @@
+/*
+ * Addition tests
+ */
+
+extern crate rustyard;
+
+#[test]
+fn can_add_two_numbers() {
+    let yard = rustyard::ShuntingYard::new("2 + 2");
+
+    assert_eq!(4f64, yard.calculate().unwrap());
+    assert_eq!("2 + 2 ", yard.to_string_ast());
+    assert_eq!("2 2 + ", yard.to_string());
+}
+
+#[test]
+fn can_add_floating_point_numbers() {
+    let yard = rustyard::ShuntingYard::new("2.5 + 2.5");
+
+    assert_eq!(5f64, yard.calculate().unwrap());
+    assert_eq!("2.5 + 2.5 ", yard.to_string_ast());
+    assert_eq!("2.5 2.5 + ", yard.to_string());
+}

--- a/tests/division.rs
+++ b/tests/division.rs
@@ -1,0 +1,23 @@
+/*
+ * Division tests
+ */
+
+extern crate rustyard;
+
+#[test]
+fn can_divide_two_numbers() {
+    let yard = rustyard::ShuntingYard::new("100 / 20");
+
+    assert_eq!(5f64, yard.calculate().unwrap());
+    assert_eq!("100 / 20 ", yard.to_string_ast());
+    assert_eq!("100 20 / ", yard.to_string());
+}
+
+#[test]
+fn can_divide_floating_point_numbers() {
+    let yard = rustyard::ShuntingYard::new("9.5 / 1.25");
+
+    assert_eq!(7.6f64, yard.calculate().unwrap());
+    assert_eq!("9.5 / 1.25 ", yard.to_string_ast());
+    assert_eq!("9.5 1.25 / ", yard.to_string());
+}

--- a/tests/multiplication.rs
+++ b/tests/multiplication.rs
@@ -1,0 +1,23 @@
+/*
+ * Multiplication tests
+ */
+
+extern crate rustyard;
+
+#[test]
+fn can_multiply_two_numbers() {
+    let yard = rustyard::ShuntingYard::new("5 * 9");
+
+    assert_eq!(45f64, yard.calculate().unwrap());
+    assert_eq!("5 * 9 ", yard.to_string_ast());
+    assert_eq!("5 9 * ", yard.to_string());
+}
+
+#[test]
+fn can_multiply_floating_point_numbers() {
+    let yard = rustyard::ShuntingYard::new("3.75 * 1.25");
+
+    assert_eq!(4.6875f64, yard.calculate().unwrap());
+    assert_eq!("3.75 * 1.25 ", yard.to_string_ast());
+    assert_eq!("3.75 1.25 * ", yard.to_string());
+}

--- a/tests/negative_numbers.rs
+++ b/tests/negative_numbers.rs
@@ -1,0 +1,41 @@
+/*
+ * Tests for negative numbers.
+ */
+
+extern crate rustyard;
+
+#[test]
+fn can_add_two_negative_numbers() {
+    let yard = rustyard::ShuntingYard::new("-2 + -2");
+
+    assert_eq!(-4f64, yard.calculate().unwrap());
+    assert_eq!("-2 + -2 ", yard.to_string_ast());
+    assert_eq!("-2 -2 + ", yard.to_string());
+}
+
+#[test]
+fn can_subtract_two_negative_numbers() {
+    let yard = rustyard::ShuntingYard::new("-2 - -2");
+
+    assert_eq!(0f64, yard.calculate().unwrap());
+    assert_eq!("-2 - -2 ", yard.to_string_ast());
+    assert_eq!("-2 -2 - ", yard.to_string());
+}
+
+#[test]
+fn can_multiply_two_negative_numbers() {
+    let yard = rustyard::ShuntingYard::new("-2 * -2");
+
+    assert_eq!(4f64, yard.calculate().unwrap());
+    assert_eq!("-2 * -2 ", yard.to_string_ast());
+    assert_eq!("-2 -2 * ", yard.to_string());
+}
+
+#[test]
+fn can_divide_two_negative_numbers() {
+    let yard = rustyard::ShuntingYard::new("-20 / -2");
+
+    assert_eq!(10f64, yard.calculate().unwrap());
+    assert_eq!("-20 / -2 ", yard.to_string_ast());
+    assert_eq!("-20 -2 / ", yard.to_string());
+}

--- a/tests/order_of_operations.rs
+++ b/tests/order_of_operations.rs
@@ -1,0 +1,95 @@
+/*
+ * Order of operations tests
+ */
+
+extern crate rustyard;
+
+#[test]
+fn multiply_before_add() {
+    let yard = rustyard::ShuntingYard::new("2 + 4 * 3");
+
+    assert_eq!(14f64, yard.calculate().unwrap());
+    assert_eq!("2 + 4 * 3 ", yard.to_string_ast());
+    assert_eq!("2 4 3 * + ", yard.to_string());
+}
+
+#[test]
+fn parenthesis_overrides_multiply_before_add() {
+    let yard = rustyard::ShuntingYard::new("(2 + 4) * 3");
+
+    assert_eq!(18f64, yard.calculate().unwrap());
+    assert_eq!("( 2 + 4 ) * 3 ", yard.to_string_ast());
+    assert_eq!("2 4 + 3 * ", yard.to_string());
+}
+
+#[test]
+fn multiply_before_subtract() {
+    let yard = rustyard::ShuntingYard::new("2 - 4 * 3");
+
+    assert_eq!(-10f64, yard.calculate().unwrap());
+    assert_eq!("2 - 4 * 3 ", yard.to_string_ast());
+    assert_eq!("2 4 3 * - ", yard.to_string());
+}
+
+#[test]
+fn parenthesis_overrides_multiply_before_subtract() {
+    let yard = rustyard::ShuntingYard::new("(2 - 4) * 3");
+
+    assert_eq!(-6f64, yard.calculate().unwrap());
+    assert_eq!("( 2 - 4 ) * 3 ", yard.to_string_ast());
+    assert_eq!("2 4 - 3 * ", yard.to_string());
+}
+
+#[test]
+fn divide_before_add() {
+    let yard = rustyard::ShuntingYard::new("2 + 20 / 4");
+
+    assert_eq!(7f64, yard.calculate().unwrap());
+    assert_eq!("2 + 20 / 4 ", yard.to_string_ast());
+    assert_eq!("2 20 4 / + ", yard.to_string());
+}
+
+#[test]
+fn parenthesis_overrides_divide_before_add() {
+    let yard = rustyard::ShuntingYard::new("(4 + 20) / 4");
+
+    assert_eq!(6f64, yard.calculate().unwrap());
+    assert_eq!("( 4 + 20 ) / 4 ", yard.to_string_ast());
+    assert_eq!("4 20 + 4 / ", yard.to_string());
+}
+
+#[test]
+fn divide_before_subtract() {
+    let yard = rustyard::ShuntingYard::new("2 - 20 / 4");
+
+    assert_eq!(-3f64, yard.calculate().unwrap());
+    assert_eq!("2 - 20 / 4 ", yard.to_string_ast());
+    assert_eq!("2 20 4 / - ", yard.to_string());
+}
+
+#[test]
+fn parenthesis_overrides_divide_before_subtract() {
+    let yard = rustyard::ShuntingYard::new("(20 - 4) / 4");
+
+    assert_eq!(4f64, yard.calculate().unwrap());
+    assert_eq!("( 20 - 4 ) / 4 ", yard.to_string_ast());
+    assert_eq!("20 4 - 4 / ", yard.to_string());
+}
+
+#[test]
+fn powers_before_everything() {
+    let yard = rustyard::ShuntingYard::new("1 + 2 * 3 ^ 3");
+
+    assert_eq!(55f64, yard.calculate().unwrap());
+    assert_eq!("1 + 2 * 3 ^ 3 ", yard.to_string_ast());
+    assert_eq!("1 2 3 3 ^ * + ", yard.to_string());
+}
+
+#[test]
+fn parenthesis_overrides_powers_before_everything() {
+    let yard = rustyard::ShuntingYard::new("1 + (2 * 3) ^ 3");
+
+    assert_eq!(217f64, yard.calculate().unwrap());
+    assert_eq!("1 + ( 2 * 3 ) ^ 3 ", yard.to_string_ast());
+    assert_eq!("1 2 3 3 ^ * + ", yard.to_string());
+}

--- a/tests/order_of_operations.rs
+++ b/tests/order_of_operations.rs
@@ -91,5 +91,5 @@ fn parenthesis_overrides_powers_before_everything() {
 
     assert_eq!(217f64, yard.calculate().unwrap());
     assert_eq!("1 + ( 2 * 3 ) ^ 3 ", yard.to_string_ast());
-    assert_eq!("1 2 3 3 ^ * + ", yard.to_string());
+    assert_eq!("1 2 3 * 3 ^ + ", yard.to_string());
 }

--- a/tests/powers.rs
+++ b/tests/powers.rs
@@ -1,0 +1,14 @@
+/*
+ * Powers tests
+ */
+
+extern crate rustyard;
+
+#[test]
+fn can_raise_to_a_power() {
+    let yard = rustyard::ShuntingYard::new("2 ^ 3");
+
+    assert_eq!(8f64, yard.calculate().unwrap());
+    assert_eq!("2 ^ 3 ", yard.to_string_ast());
+    assert_eq!("2 3 ^ ", yard.to_string());
+}

--- a/tests/subtraction.rs
+++ b/tests/subtraction.rs
@@ -1,0 +1,23 @@
+/*
+ * Subtraction tests
+ */
+
+extern crate rustyard;
+
+#[test]
+fn can_subtract_two_numbers() {
+    let yard = rustyard::ShuntingYard::new("5 - 2");
+
+    assert_eq!(3f64, yard.calculate().unwrap());
+    assert_eq!("5 - 2 ", yard.to_string_ast());
+    assert_eq!("5 2 - ", yard.to_string());
+}
+
+#[test]
+fn can_subtract_floating_point_numbers() {
+    let yard = rustyard::ShuntingYard::new("3.75 - 1.25");
+
+    assert_eq!(2.5f64, yard.calculate().unwrap());
+    assert_eq!("3.75 - 1.25 ", yard.to_string_ast());
+    assert_eq!("3.75 1.25 - ", yard.to_string());
+}

--- a/tests/wikipedia.rs
+++ b/tests/wikipedia.rs
@@ -1,0 +1,12 @@
+/*
+ * Tests the results of the ShuntingYard examples on Wikipedia
+ */
+
+extern crate rustyard;
+
+#[test]
+fn wikipedia_one() {
+    let yard = rustyard::ShuntingYard::new("3 + 4 * 2 / ( 1 - 5 ) ^ 2 ^ 3");
+
+    assert_eq!("3 4 2 * 1 5 - 2 3 ^ ^ / + ", yard.to_string());
+}


### PR DESCRIPTION
This PR introduces the ability to utilize negative numbers in expressions (a basic requirement I may have overlooked in the initial release!).

Some examples:

_NOTE: Because of the way `cargo run` accepts flags.. you have to build the example first then run it manually for the negative sign to be recognised_.

```
Simon$ cargo build --example main
Simon$ target/debug/examples/main "-2 * 2"
Input is: -2 * 2
Lexer result: -2  *  2
Shunting Yard result: -2 2 *
Equation equals: -4
Simon$ target/debug/examples/main "-2 * -2"
Input is: -2 * -2
Lexer result: -2  *  -2
Shunting Yard result: -2 -2 *
Equation equals: 4
```
