### PR TITLE
Feature: Nicer errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustyard"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Simon Whitehead <chemnova@gmail.com>"]
 description = "A Shunting Yard implementation and calculator. This crate is able to calculate basic math expressions passed to it as strings and return a 64-bit floating point return value."
 repository = "http://github.com/simon-whitehead/rust-yard"

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -9,20 +9,15 @@ fn main() {
 
             println!("Input is: {}", input);
 
-            if shunting_yard.errors.len() > 0 {
-                println!("Errors:");
-                for err in shunting_yard.errors {
-                    println!("ERR: {}", err);
-                }
-            } else {
-                match shunting_yard.calculate() {
-                    Some(n) => {
-                        println!("Lexer result: {}", shunting_yard.to_string_ast());
-                        println!("Shunting Yard result: {}", shunting_yard.to_string());
-                        println!("Equation equals: {}", n);
-                    },
-                    None =>  {
-                        println!("Unable to calculate a result");
+            match shunting_yard.calculate() {
+                Ok(n) => {
+                    println!("Lexer result: {}", shunting_yard.to_string_ast());
+                    println!("Shunting Yard result: {}", shunting_yard.to_string());
+                    println!("Equation equals: {}", n);
+                },
+                Err(errors) =>  {
+                    for err in errors {
+                        println!("ERR: {}", err);
                     }
                 }
             }

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -14,7 +14,7 @@ pub struct ShuntingYard<'a> {
     lexer: lexer::Lexer<'a>,
     output_queue: Vec<token::Token>,
     stack: Vec<token::Token>,
-    pub errors: Vec<String>
+    errors: Vec<String>
 }
 
 impl<'a> ShuntingYard<'a> {

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -38,8 +38,18 @@ impl<'a> ShuntingYard<'a> {
     /// calculate returns a 64-bit floating value after
     /// parsing the Reverse Polish Notation represented
     /// by the output_queue.
-    pub fn calculate(&self) -> Option<f64> {
-        calc::calculate(&self.output_queue)
+    pub fn calculate(&self) -> Result<f64, Vec<String>> {
+        // If there are lexer errors, return early with them
+        if self.errors.len() > 0 {
+            return Err(self.errors.clone())
+        }
+
+        match calc::calculate(&self.output_queue) {
+            Some(n) => {
+                Ok(n)
+            },
+            _ => Err(vec!["Unable to calculate a result".to_string()])
+        }
     }
 
     // Transforms the input from the Lexer in to the output_queue

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,0 +1,23 @@
+/*
+ * Error testing
+ */
+
+extern crate rustyard;
+
+#[test]
+fn can_detect_unbalanced_parenthesis() {
+    let yard = rustyard::ShuntingYard::new("100 / 20 )");
+
+    let err = &yard.calculate().unwrap_err()[0];
+
+    assert_eq!("Unbalanced parenthesis", &err[..]);
+}
+
+#[test]
+fn can_detect_unknown_identifiers() {
+    let yard = rustyard::ShuntingYard::new("2a + 4");
+
+    let err = &yard.calculate().unwrap_err()[0];
+
+    assert_eq!("Unknown identifier: a", &err[..]);
+}


### PR DESCRIPTION
This PR makes consuming the errors generated by the library nicer. Instead of checking the `ShuntingYard` instance for errors, `calculate` now returns a `Result<f64, Vec<String>>` that can be matched on.
