### PR TITLE
Feature: Single instance, multiple calculations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustyard"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Simon Whitehead <chemnova@gmail.com>"]
 description = "A Shunting Yard implementation and calculator. This crate is able to calculate basic math expressions passed to it as strings and return a 64-bit floating point return value."
 repository = "http://github.com/simon-whitehead/rust-yard"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can instantiate a `ShuntingYard` instance with an expression and call its `c
 extern crate rustyard;
 
 fn main() {
-    let yard = rustyard::ShuntingYard::new();
+    let mut yard = rustyard::ShuntingYard::new();
 
     // This prints "The result is: 14"
     println!("The result is: {}", yard.calculate("2 + 4 * 3").unwrap());

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ You can instantiate a `ShuntingYard` instance with an expression and call its `c
 extern crate rustyard;
 
 fn main() {
-    let yard = rustyard::ShuntingYard::new("2 + 4 * 3");
+    let yard = rustyard::ShuntingYard::new();
 
     // This prints "The result is: 14"
-    println!("The result is: {}", yard.calculate().unwrap());
+    println!("The result is: {}", yard.calculate("2 + 4 * 3").unwrap());
 }
 ```
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -21,19 +21,6 @@ fn main() {
                     }
                 }
             }
-
-            match shunting_yard.calculate("4 * 4") {
-                Ok(n) => {
-                    println!("Lexer result: {}", shunting_yard.to_string_ast());
-                    println!("Shunting Yard result: {}", shunting_yard.to_string());
-                    println!("Equation equals: {}", n);
-                },
-                Err(errors) =>  {
-                    for err in errors {
-                        println!("ERR: {}", err);
-                    }
-                }
-            }
         },
         None => println!("Please supply an expression")
     };

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -21,6 +21,19 @@ fn main() {
                     }
                 }
             }
+
+            match shunting_yard.calculate("4 * 4") {
+                Ok(n) => {
+                    println!("Lexer result: {}", shunting_yard.to_string_ast());
+                    println!("Shunting Yard result: {}", shunting_yard.to_string());
+                    println!("Equation equals: {}", n);
+                },
+                Err(errors) =>  {
+                    for err in errors {
+                        println!("ERR: {}", err);
+                    }
+                }
+            }
         },
         None => println!("Please supply an expression")
     };

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -5,11 +5,11 @@ use std::env;
 fn main() {
     match env::args().nth(1) {
         Some(input) => {
-            let shunting_yard = rustyard::ShuntingYard::new(&input[..]);
+            let mut shunting_yard = rustyard::ShuntingYard::new();
 
             println!("Input is: {}", input);
 
-            match shunting_yard.calculate() {
+            match shunting_yard.calculate(&input[..]) {
                 Ok(n) => {
                     println!("Lexer result: {}", shunting_yard.to_string_ast());
                     println!("Shunting Yard result: {}", shunting_yard.to_string());

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -11,18 +11,17 @@ pub struct Lexer<'a> {
 }
 
 impl<'a> Lexer<'a> {
-    pub fn new(input: &str) -> Lexer {
-        let mut l = Lexer { 
+    pub fn new() -> Lexer<'a> {
+        Lexer { 
             ast: Vec::new(),
             errors: vec![],
-            iter: peek::PeekableStringIterator::new(input),
+            iter: peek::PeekableStringIterator::new(),
             sign: None
-        };
-        l.lex();
-        l
+        }
     }
 
-    fn lex(&mut self) {
+    pub fn lex(&mut self, raw_input: &'a str) {
+        self.iter.set_input(raw_input);
         self.consume_input();
     }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -21,6 +21,10 @@ impl<'a> Lexer<'a> {
     }
 
     pub fn lex(&mut self, raw_input: &'a str) {
+        // Clear out everything
+        self.ast.clear();
+        self.errors.clear();
+
         self.iter.set_input(raw_input);
         self.consume_input();
     }

--- a/src/peekable_string_iterator.rs
+++ b/src/peekable_string_iterator.rs
@@ -10,10 +10,14 @@ pub struct PeekableStringIterator<'a> {
 }
 
 impl<'a> PeekableStringIterator<'a> {
-    pub fn new(raw_input: &str) -> PeekableStringIterator {
+    pub fn new() -> PeekableStringIterator<'a> {
         PeekableStringIterator {
-            iter: raw_input.chars().peekable()
+            iter: "".chars().peekable()
         }
+    }
+
+    pub fn set_input(&mut self, raw_input: &'a str) {
+        self.iter = raw_input.chars().peekable();
     }
 
     pub fn advance(&mut self) {

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -31,7 +31,12 @@ impl<'a> ShuntingYard<'a> {
     /// parsing the Reverse Polish Notation represented
     /// by the output_queue.
     pub fn calculate(&mut self, raw_input: &'a str) -> Result<f64, Vec<String>> {
-        // Instantiate a Lexer
+        // Clear out everything
+        self.output_queue.clear();
+        self.stack.clear();
+        self.errors.clear();
+
+        // Lex the input
         self.lexer.lex(raw_input);
 
         // If there were Lexer errors, add them now.

--- a/src/shunting_yard.rs
+++ b/src/shunting_yard.rs
@@ -18,27 +18,29 @@ pub struct ShuntingYard<'a> {
 }
 
 impl<'a> ShuntingYard<'a> {
-    pub fn new(raw_input: &str) -> ShuntingYard {
-        let mut yard = ShuntingYard {
-            lexer: lexer::Lexer::new(raw_input),
+    pub fn new() -> ShuntingYard<'a> {
+        ShuntingYard {
+            lexer: lexer::Lexer::new(),
             output_queue: vec![],
             stack: vec![],
             errors: vec![]
-        };
-
-        // If there were Lexer errors, add them now.
-        let lexer_errors = yard.lexer.errors.clone();
-        yard.errors.extend(lexer_errors);
-
-        // Transform the Lexer input via the Shunting Yard algorithm
-        yard.transform();
-        yard
+        }
     }
 
     /// calculate returns a 64-bit floating value after
     /// parsing the Reverse Polish Notation represented
     /// by the output_queue.
-    pub fn calculate(&self) -> Result<f64, Vec<String>> {
+    pub fn calculate(&mut self, raw_input: &'a str) -> Result<f64, Vec<String>> {
+        // Instantiate a Lexer
+        self.lexer.lex(raw_input);
+
+        // If there were Lexer errors, add them now.
+        let lexer_errors = self.lexer.errors.clone();
+        self.errors.extend(lexer_errors);
+
+        // Transform the Lexer input via the Shunting Yard algorithm
+        self.transform();
+
         // If there are lexer errors, return early with them
         if self.errors.len() > 0 {
             return Err(self.errors.clone())

--- a/tests/addition.rs
+++ b/tests/addition.rs
@@ -6,18 +6,18 @@ extern crate rustyard;
 
 #[test]
 fn can_add_two_numbers() {
-    let yard = rustyard::ShuntingYard::new("2 + 2");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(4f64, yard.calculate().unwrap());
+    assert_eq!(4f64, yard.calculate("2 + 2").unwrap());
     assert_eq!("2 + 2 ", yard.to_string_ast());
     assert_eq!("2 2 + ", yard.to_string());
 }
 
 #[test]
 fn can_add_floating_point_numbers() {
-    let yard = rustyard::ShuntingYard::new("2.5 + 2.5");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(5f64, yard.calculate().unwrap());
+    assert_eq!(5f64, yard.calculate("2.5 + 2.5").unwrap());
     assert_eq!("2.5 + 2.5 ", yard.to_string_ast());
     assert_eq!("2.5 2.5 + ", yard.to_string());
 }

--- a/tests/division.rs
+++ b/tests/division.rs
@@ -6,18 +6,18 @@ extern crate rustyard;
 
 #[test]
 fn can_divide_two_numbers() {
-    let yard = rustyard::ShuntingYard::new("100 / 20");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(5f64, yard.calculate().unwrap());
+    assert_eq!(5f64, yard.calculate("100 / 20").unwrap());
     assert_eq!("100 / 20 ", yard.to_string_ast());
     assert_eq!("100 20 / ", yard.to_string());
 }
 
 #[test]
 fn can_divide_floating_point_numbers() {
-    let yard = rustyard::ShuntingYard::new("9.5 / 1.25");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(7.6f64, yard.calculate().unwrap());
+    assert_eq!(7.6f64, yard.calculate("9.5 / 1.25").unwrap());
     assert_eq!("9.5 / 1.25 ", yard.to_string_ast());
     assert_eq!("9.5 1.25 / ", yard.to_string());
 }

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -6,18 +6,18 @@ extern crate rustyard;
 
 #[test]
 fn can_detect_unbalanced_parenthesis() {
-    let yard = rustyard::ShuntingYard::new("100 / 20 )");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    let err = &yard.calculate().unwrap_err()[0];
+    let err = &yard.calculate("100 / 20 )").unwrap_err()[0];
 
     assert_eq!("Unbalanced parenthesis", &err[..]);
 }
 
 #[test]
 fn can_detect_unknown_identifiers() {
-    let yard = rustyard::ShuntingYard::new("2a + 4");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    let err = &yard.calculate().unwrap_err()[0];
+    let err = &yard.calculate("2a + 4").unwrap_err()[0];
 
     assert_eq!("Unknown identifier: a", &err[..]);
 }

--- a/tests/multi-expression.rs
+++ b/tests/multi-expression.rs
@@ -1,0 +1,19 @@
+/*
+ * Multiple expressions - make sure a single ShuntingYard
+ * instance can calculate more than one expression.
+ */
+
+extern crate rustyard;
+
+#[test]
+fn can_calculate_twice_with_single_instance() {
+    let mut yard = rustyard::ShuntingYard::new();
+
+    assert_eq!(4f64, yard.calculate("2 + 2").unwrap());
+    assert_eq!("2 + 2 ", yard.to_string_ast());
+    assert_eq!("2 2 + ", yard.to_string());
+
+    assert_eq!(-4f64, yard.calculate("2 * -2").unwrap());
+    assert_eq!("2 * -2 ", yard.to_string_ast());
+    assert_eq!("2 -2 * ", yard.to_string());
+}

--- a/tests/multiplication.rs
+++ b/tests/multiplication.rs
@@ -6,18 +6,18 @@ extern crate rustyard;
 
 #[test]
 fn can_multiply_two_numbers() {
-    let yard = rustyard::ShuntingYard::new("5 * 9");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(45f64, yard.calculate().unwrap());
+    assert_eq!(45f64, yard.calculate("5 * 9").unwrap());
     assert_eq!("5 * 9 ", yard.to_string_ast());
     assert_eq!("5 9 * ", yard.to_string());
 }
 
 #[test]
 fn can_multiply_floating_point_numbers() {
-    let yard = rustyard::ShuntingYard::new("3.75 * 1.25");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(4.6875f64, yard.calculate().unwrap());
+    assert_eq!(4.6875f64, yard.calculate("3.75 * 1.25").unwrap());
     assert_eq!("3.75 * 1.25 ", yard.to_string_ast());
     assert_eq!("3.75 1.25 * ", yard.to_string());
 }

--- a/tests/negative_numbers.rs
+++ b/tests/negative_numbers.rs
@@ -6,36 +6,36 @@ extern crate rustyard;
 
 #[test]
 fn can_add_two_negative_numbers() {
-    let yard = rustyard::ShuntingYard::new("-2 + -2");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(-4f64, yard.calculate().unwrap());
+    assert_eq!(-4f64, yard.calculate("-2 + -2").unwrap());
     assert_eq!("-2 + -2 ", yard.to_string_ast());
     assert_eq!("-2 -2 + ", yard.to_string());
 }
 
 #[test]
 fn can_subtract_two_negative_numbers() {
-    let yard = rustyard::ShuntingYard::new("-2 - -2");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(0f64, yard.calculate().unwrap());
+    assert_eq!(0f64, yard.calculate("-2 - -2").unwrap());
     assert_eq!("-2 - -2 ", yard.to_string_ast());
     assert_eq!("-2 -2 - ", yard.to_string());
 }
 
 #[test]
 fn can_multiply_two_negative_numbers() {
-    let yard = rustyard::ShuntingYard::new("-2 * -2");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(4f64, yard.calculate().unwrap());
+    assert_eq!(4f64, yard.calculate("-2 * -2").unwrap());
     assert_eq!("-2 * -2 ", yard.to_string_ast());
     assert_eq!("-2 -2 * ", yard.to_string());
 }
 
 #[test]
 fn can_divide_two_negative_numbers() {
-    let yard = rustyard::ShuntingYard::new("-20 / -2");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(10f64, yard.calculate().unwrap());
+    assert_eq!(10f64, yard.calculate("-20 / -2").unwrap());
     assert_eq!("-20 / -2 ", yard.to_string_ast());
     assert_eq!("-20 -2 / ", yard.to_string());
 }

--- a/tests/order_of_operations.rs
+++ b/tests/order_of_operations.rs
@@ -6,90 +6,90 @@ extern crate rustyard;
 
 #[test]
 fn multiply_before_add() {
-    let yard = rustyard::ShuntingYard::new("2 + 4 * 3");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(14f64, yard.calculate().unwrap());
+    assert_eq!(14f64, yard.calculate("2 + 4 * 3").unwrap());
     assert_eq!("2 + 4 * 3 ", yard.to_string_ast());
     assert_eq!("2 4 3 * + ", yard.to_string());
 }
 
 #[test]
 fn parenthesis_overrides_multiply_before_add() {
-    let yard = rustyard::ShuntingYard::new("(2 + 4) * 3");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(18f64, yard.calculate().unwrap());
+    assert_eq!(18f64, yard.calculate("(2 + 4) * 3").unwrap());
     assert_eq!("( 2 + 4 ) * 3 ", yard.to_string_ast());
     assert_eq!("2 4 + 3 * ", yard.to_string());
 }
 
 #[test]
 fn multiply_before_subtract() {
-    let yard = rustyard::ShuntingYard::new("2 - 4 * 3");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(-10f64, yard.calculate().unwrap());
+    assert_eq!(-10f64, yard.calculate("2 - 4 * 3").unwrap());
     assert_eq!("2 - 4 * 3 ", yard.to_string_ast());
     assert_eq!("2 4 3 * - ", yard.to_string());
 }
 
 #[test]
 fn parenthesis_overrides_multiply_before_subtract() {
-    let yard = rustyard::ShuntingYard::new("(2 - 4) * 3");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(-6f64, yard.calculate().unwrap());
+    assert_eq!(-6f64, yard.calculate("(2 - 4) * 3").unwrap());
     assert_eq!("( 2 - 4 ) * 3 ", yard.to_string_ast());
     assert_eq!("2 4 - 3 * ", yard.to_string());
 }
 
 #[test]
 fn divide_before_add() {
-    let yard = rustyard::ShuntingYard::new("2 + 20 / 4");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(7f64, yard.calculate().unwrap());
+    assert_eq!(7f64, yard.calculate("2 + 20 / 4").unwrap());
     assert_eq!("2 + 20 / 4 ", yard.to_string_ast());
     assert_eq!("2 20 4 / + ", yard.to_string());
 }
 
 #[test]
 fn parenthesis_overrides_divide_before_add() {
-    let yard = rustyard::ShuntingYard::new("(4 + 20) / 4");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(6f64, yard.calculate().unwrap());
+    assert_eq!(6f64, yard.calculate("(4 + 20) / 4").unwrap());
     assert_eq!("( 4 + 20 ) / 4 ", yard.to_string_ast());
     assert_eq!("4 20 + 4 / ", yard.to_string());
 }
 
 #[test]
 fn divide_before_subtract() {
-    let yard = rustyard::ShuntingYard::new("2 - 20 / 4");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(-3f64, yard.calculate().unwrap());
+    assert_eq!(-3f64, yard.calculate("2 - 20 / 4").unwrap());
     assert_eq!("2 - 20 / 4 ", yard.to_string_ast());
     assert_eq!("2 20 4 / - ", yard.to_string());
 }
 
 #[test]
 fn parenthesis_overrides_divide_before_subtract() {
-    let yard = rustyard::ShuntingYard::new("(20 - 4) / 4");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(4f64, yard.calculate().unwrap());
+    assert_eq!(4f64, yard.calculate("(20 - 4) / 4").unwrap());
     assert_eq!("( 20 - 4 ) / 4 ", yard.to_string_ast());
     assert_eq!("20 4 - 4 / ", yard.to_string());
 }
 
 #[test]
 fn powers_before_everything() {
-    let yard = rustyard::ShuntingYard::new("1 + 2 * 3 ^ 3");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(55f64, yard.calculate().unwrap());
+    assert_eq!(55f64, yard.calculate("1 + 2 * 3 ^ 3").unwrap());
     assert_eq!("1 + 2 * 3 ^ 3 ", yard.to_string_ast());
     assert_eq!("1 2 3 3 ^ * + ", yard.to_string());
 }
 
 #[test]
 fn parenthesis_overrides_powers_before_everything() {
-    let yard = rustyard::ShuntingYard::new("1 + (2 * 3) ^ 3");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(217f64, yard.calculate().unwrap());
+    assert_eq!(217f64, yard.calculate("1 + (2 * 3) ^ 3").unwrap());
     assert_eq!("1 + ( 2 * 3 ) ^ 3 ", yard.to_string_ast());
     assert_eq!("1 2 3 * 3 ^ + ", yard.to_string());
 }

--- a/tests/powers.rs
+++ b/tests/powers.rs
@@ -6,9 +6,9 @@ extern crate rustyard;
 
 #[test]
 fn can_raise_to_a_power() {
-    let yard = rustyard::ShuntingYard::new("2 ^ 3");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(8f64, yard.calculate().unwrap());
+    assert_eq!(8f64, yard.calculate("2 ^ 3").unwrap());
     assert_eq!("2 ^ 3 ", yard.to_string_ast());
     assert_eq!("2 3 ^ ", yard.to_string());
 }

--- a/tests/subtraction.rs
+++ b/tests/subtraction.rs
@@ -6,18 +6,18 @@ extern crate rustyard;
 
 #[test]
 fn can_subtract_two_numbers() {
-    let yard = rustyard::ShuntingYard::new("5 - 2");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(3f64, yard.calculate().unwrap());
+    assert_eq!(3f64, yard.calculate("5 - 2").unwrap());
     assert_eq!("5 - 2 ", yard.to_string_ast());
     assert_eq!("5 2 - ", yard.to_string());
 }
 
 #[test]
 fn can_subtract_floating_point_numbers() {
-    let yard = rustyard::ShuntingYard::new("3.75 - 1.25");
+    let mut yard = rustyard::ShuntingYard::new();
 
-    assert_eq!(2.5f64, yard.calculate().unwrap());
+    assert_eq!(2.5f64, yard.calculate("3.75 - 1.25").unwrap());
     assert_eq!("3.75 - 1.25 ", yard.to_string_ast());
     assert_eq!("3.75 1.25 - ", yard.to_string());
 }

--- a/tests/wikipedia.rs
+++ b/tests/wikipedia.rs
@@ -6,7 +6,8 @@ extern crate rustyard;
 
 #[test]
 fn wikipedia_one() {
-    let yard = rustyard::ShuntingYard::new("3 + 4 * 2 / ( 1 - 5 ) ^ 2 ^ 3");
+    let mut yard = rustyard::ShuntingYard::new();
 
+    yard.calculate("3 + 4 * 2 / ( 1 - 5 ) ^ 2 ^ 3").unwrap();
     assert_eq!("3 4 2 * 1 5 - 2 3 ^ ^ / + ", yard.to_string());
 }

--- a/tests/wikipedia.rs
+++ b/tests/wikipedia.rs
@@ -8,6 +8,6 @@ extern crate rustyard;
 fn wikipedia_one() {
     let mut yard = rustyard::ShuntingYard::new();
 
-    yard.calculate("3 + 4 * 2 / ( 1 - 5 ) ^ 2 ^ 3").unwrap();
+    assert_eq!(3.0001220703125f64, yard.calculate("3 + 4 * 2 / ( 1 - 5 ) ^ 2 ^ 3").unwrap());
     assert_eq!("3 4 2 * 1 5 - 2 3 ^ ^ / + ", yard.to_string());
 }


### PR DESCRIPTION
This PR changes the API to allow re-use of the `calculate` method.

Instead of passing the expression via the constructor of `ShuntingYard`, you now pass it to the calculate method itself:

Old way:

```
let yard = rustyard::ShuntingYard::new("2 + 2");
println!("Result: {}", yard.calculate().unwrap()); // 4

let yard = rustyard::ShuntingYard::new("4 * 4");
println!("Result: {}", yard.calculate().unwrap()); // 16
```

New way:

```
let mut yard = rustyard::ShuntingYard::new();
println!("Result: {}", yard.calculate("2 + 2").unwrap()); // 4
println!("Result: {}", yard.calculate("4 * 4").unwrap()); // 16
```

This allows re-use of a single instance of a `ShuntingYard` to perform multiple calculations.
